### PR TITLE
Enhaced regex for usernames

### DIFF
--- a/scripts/daily_update.js
+++ b/scripts/daily_update.js
@@ -44,7 +44,7 @@ module.exports = function(robot) {
       }
     });
 
-    robot.respond(/get daily updates by (\w*)/i, function(msg) {
+    robot.respond(/get daily updates by ([a-z0-9][a-z0-9. _-]*)/i, function(msg) {
       var username = msg.match[1];
       var room = msg.envelope.user.room;
       var today = getToday();
@@ -104,7 +104,7 @@ module.exports = function(robot) {
       msg.send('removed all updates for '+username+' on '+date);
     });
 
-    robot.respond(/remove daily updates by (\w+)/i, function (msg) {
+    robot.respond(/remove daily updates by ([a-z0-9][a-z0-9. _-]*)/i, function (msg) {
       var username = msg.match[1];
       var room = msg.envelope.user.room;
       var roomMessages = getRoomMessages(room);


### PR DESCRIPTION
Will now match:
JohnFoley
John Foley
John_Foley
John.Foley
John-Foley

While maintaining that there be at least one alphanumeric character in front. Since `remove by` and `get updates by` do not have any content after the username, it should be safe to eat up all of the text after a space.
Fixes #2 
