### PR TITLE
Commutative standup notes and misc. fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-daily-update",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Hubot script to save daily updates.",
   "main": "index.js",
   "scripts": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-daily-update",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Hubot script to save daily updates.",
   "main": "index.js",
   "scripts": {},

--- a/scripts/daily_update.js
+++ b/scripts/daily_update.js
@@ -27,8 +27,8 @@ module.exports = function(robot) {
 
     robot.respond(/my update is (.*)/i, function(msg) {
       var dailyUpdate = msg.match[1];
+      var username = msg.envelope.user.name;
       if(dailyUpdate.length > 0) {
-        var username = msg.envelope.user.name;
         var room = msg.envelope.user.room;
         var today = getToday();
         var messages = getRoomMessages(room);
@@ -38,24 +38,25 @@ module.exports = function(robot) {
 
         saveRoomMessages(room, messages);
 
-        msg.send('added your daily update');
+        msg.send('Sure ' + username + ', added your daily update.');
       } else {
-        msg.send('Sorry, your update is empty. Try again');
+        msg.send('Sorry ' + username + ', your update is empty. Try again');
       }
     });
 
     robot.respond(/get daily updates by (\w*)/i, function(msg) {
       var username = msg.match[1];
+      var requester_username = msg.envelope.user.name;
       var room = msg.envelope.user.room;
       var today = getToday();
       var messages = getRoomMessages(room);
 
       if(username.length === 0)
-        return msg.send('You need to supply a user name');
+        return msg.send(requester_username + ', you need to supply a user name');
       if(!(username in messages))
-        return msg.send('This user does not exist or has never stored any updates');
+        return msg.send('This user(' + username + ') does not exist or has never stored any updates');
       if(!(today in messages[username]) || messages[username][today].length === 0)
-        return msg.send('No daily updates for this user yet');
+        return msg.send('No daily updates for this user(' + username + ') yet');
 
       msg.send(
         'Daily update of '+today+' by '+username+':\n'+

--- a/scripts/daily_update.js
+++ b/scripts/daily_update.js
@@ -26,7 +26,7 @@ var moment = require('moment');
 module.exports = function(robot) {
 
     robot.respond(/my update is((.*\s*)+)/i, function(msg) {
-      var dailyUpdate = msg.match[1];
+      var dailyUpdate = msg.match[1].trimLeft();  // Trimming the leading (left) whitespaces
       var username = msg.envelope.user.name;
       if(dailyUpdate.length > 0) {
         var room = msg.envelope.user.room;

--- a/scripts/daily_update.js
+++ b/scripts/daily_update.js
@@ -25,7 +25,7 @@ var moment = require('moment');
 
 module.exports = function(robot) {
 
-    robot.respond(/my update is (.*)/i, function(msg) {
+    robot.respond(/my update is ((.*\s*)+)/i, function(msg) {
       var dailyUpdate = msg.match[1];
       if(dailyUpdate.length > 0) {
         var username = msg.envelope.user.name;
@@ -33,8 +33,9 @@ module.exports = function(robot) {
         var today = getToday();
         var messages = getRoomMessages(room);
         messages[username] = messages[username] || {};
-        messages[username][today] = messages[username][today] || [];
-        messages[username][today].push(dailyUpdate);
+        // Always override the earlier update for today.
+        // messages[username][today] = messages[username][today] || [];
+        messages[username][today] = [dailyUpdate];
 
         saveRoomMessages(room, messages);
 

--- a/scripts/daily_update.js
+++ b/scripts/daily_update.js
@@ -25,7 +25,7 @@ var moment = require('moment');
 
 module.exports = function(robot) {
 
-    robot.respond(/my update is ((.*\s*)+)/i, function(msg) {
+    robot.respond(/my update is((.*\s*)+)/i, function(msg) {
       var dailyUpdate = msg.match[1];
       if(dailyUpdate.length > 0) {
         var username = msg.envelope.user.name;


### PR DESCRIPTION
1. Make changes to store/update commutative standup notes (by https://github.com/ayadav)
a. Add support to get multiline standup notes
b. Always override with latest standup notes rather than append.
2. Allow empty first line message (remove preceding space) (by https://github.com/ayadav)
3. Trimming the leading (left) whitespaces in the daily updates (by https://github.com/sandipagarwal)
4. add usernames in messages for realistic conversation with hubot (by https://github.com/sandipagarwal)